### PR TITLE
Use generic sniff for forbidden functions

### DIFF
--- a/PSR12NeutronRuleset/ruleset.xml
+++ b/PSR12NeutronRuleset/ruleset.xml
@@ -6,7 +6,7 @@
 
     <!-- Bad parts of PHP -->
     <rule ref="Generic.PHP.NoSilencedErrors"/>
-    <rule ref="Squiz.PHP.DiscouragedFunctions">
+    <rule ref="Generic.PHP.ForbiddenFunctions">
         <properties>
             <property name="forbiddenFunctions" type="array">
                 <!-- See disable_functions PHP-FPM configuration -->


### PR DESCRIPTION
Note from [Wiki](https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Customisable-Sniff-Properties#squizphpdiscouragedfunctions):
> [!NOTE]  
> This sniff also has a forbiddenFunctions property inherited from the [Generic.PHP.ForbiddenFunctions](https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Customisable-Sniff-Properties#genericphpforbiddenfunctions) sniff, but it should not be used. If you want to customise the list of discouraged functions, use the Generic.PHP.ForbiddenFunctions sniff directly.