### PR TITLE
Remove ImportDetection rules

### DIFF
--- a/PSR12NeutronRuleset/NeutronRuleset.xml
+++ b/PSR12NeutronRuleset/NeutronRuleset.xml
@@ -3,7 +3,6 @@
     <description>Neutron Ruleset.</description>
     <rule ref="VariableAnalysis"/>
     <rule ref="NeutronStandard"/>
-    <rule ref="ImportDetection"/>
     <rule ref="WordPress-Core"/>
     <rule ref="Squiz.Commenting">
         <severity>0</severity>

--- a/PSR12NeutronRuleset/NeutronRuleset.xml
+++ b/PSR12NeutronRuleset/NeutronRuleset.xml
@@ -8,13 +8,6 @@
     <rule ref="Squiz.Commenting">
         <severity>0</severity>
     </rule>
-    <rule ref="ImportDetection.Imports.RequireImports">
-        <properties>
-            <property name="ignoreUnimportedSymbols" value="/^(BD_PROCESSOR_[A-Z_]+|BD_STRIPE_[A-Z_]+|BD_PAYPAL_[A-Z_]+|BD_TXN[A-Z_]+|BD_TYPE[A-Z_]+|BILLINGDADDY_HOME|require_lib|WPCOM_[A-Z_]+|tracks_record_event|BD_INTERVAL_[A-Z_]+)$/"/>
-            <property name="ignoreGlobalsWhenInGlobalScope" value="true"/>
-            <property name="ignoreWordPressSymbols" value="true"/>
-        </properties>
-    </rule>
     <rule ref="PEAR.Functions.FunctionCallSignature.MultipleArguments">
         <severity>0</severity>
     </rule>
@@ -56,9 +49,6 @@
     </rule>
     <rule ref="WordPress.DB.DirectDatabaseQuery.NoCaching">
         <severity>0</severity>
-    </rule>
-    <rule ref="ImportDetection.Imports.RequireImports.Import">
-        <type>error</type>
     </rule>
     <rule ref="VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable">
         <type>error</type>

--- a/PSR12NeutronRuleset/ruleset.xml
+++ b/PSR12NeutronRuleset/ruleset.xml
@@ -141,9 +141,6 @@
         <exclude name="NeutronStandard.StrictTypes.RequireStrictTypes"/>
 
         <exclude name="VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable"/>
-
-        <!-- https://github.com/sirbrillig/phpcs-import-detection/issues/45 -->
-        <exclude name="ImportDetection.Imports.RequireImports"/>
     </rule>
     <!-- WordPress-Core opposite rules -->
     <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>


### PR DESCRIPTION
Removes the ImportDetection rules as ImportDetection.Imports.RequireImports.Import is excluded, this is best handled via static analysis and the ImportDetection repo owner discourages the use of this rule set.

Closes #1