### PR TITLE
Remove SlevomatCodingStandard.PHP.UselessSemicolon rule

### DIFF
--- a/PSR12NeutronRuleset/ruleset.xml
+++ b/PSR12NeutronRuleset/ruleset.xml
@@ -214,7 +214,6 @@
     <rule ref="SlevomatCodingStandard.PHP.RequireExplicitAssertion"/>
     <rule ref="SlevomatCodingStandard.PHP.RequireNowdoc"/>
     <rule ref="SlevomatCodingStandard.PHP.OptimizedFunctionsWithoutUnpacking"/>
-    <rule ref="SlevomatCodingStandard.PHP.UselessSemicolon"/>
     <rule ref="SlevomatCodingStandard.Variables.DuplicateAssignmentToVariable"/>
     <rule ref="SlevomatCodingStandard.Variables.UnusedVariable"/>
     <rule ref="SlevomatCodingStandard.Variables.UselessVariable"/>


### PR DESCRIPTION
Removing useless semicolons is covered by Generic.CodeAnalysis.EmptyPHPStatement (SemicolonWithoutCodeDetected).