### PR TITLE
Exclude WP_Error from FullyQualifiedExceptionsSniff

### DIFF
--- a/PSR12NeutronRuleset/ruleset.xml
+++ b/PSR12NeutronRuleset/ruleset.xml
@@ -248,7 +248,13 @@
             <property name="namespacesRequiredToUse" type="array"/>
         </properties>
     </rule>
-    <rule ref="SlevomatCodingStandard.Namespaces.FullyQualifiedExceptions"/>
+    <rule ref="SlevomatCodingStandard.Namespaces.FullyQualifiedExceptions">
+        <properties>
+            <property name="ignoredNames" type="array">
+                <element value="WP_Error"/>
+            </property>
+        </properties>
+    </rule>
     <rule ref="SlevomatCodingStandard.Namespaces.MultipleUsesPerLine"/>
     <rule ref="SlevomatCodingStandard.Namespaces.UseDoesNotStartWithBackslash"/>
     <rule ref="SlevomatCodingStandard.Namespaces.FullyQualifiedClassNameInAnnotation"/>


### PR DESCRIPTION
`WP_Error` is not an exception.