### PR TITLE
Set `ignoreStandaloneIfInScope` in early exit sniff

### DIFF
--- a/PSR12NeutronRuleset/ruleset.xml
+++ b/PSR12NeutronRuleset/ruleset.xml
@@ -215,7 +215,7 @@
     <rule ref="SlevomatCodingStandard.ControlStructures.RequireNullCoalesceOperator"/>
     <rule ref="SlevomatCodingStandard.ControlStructures.EarlyExit">
         <properties>
-            <property name="ignoreStandaloneIfInScope" value="true">
+            <property name="ignoreStandaloneIfInScope" value="true"/>
         </properties>
     </rule>
     <rule ref="SlevomatCodingStandard.Functions.StaticClosure"/>

--- a/PSR12NeutronRuleset/ruleset.xml
+++ b/PSR12NeutronRuleset/ruleset.xml
@@ -213,7 +213,11 @@
     <rule ref="SlevomatCodingStandard.ControlStructures.DisallowContinueWithoutIntegerOperandInSwitch"/>
     <rule ref="SlevomatCodingStandard.ControlStructures.DisallowEmpty"/>
     <rule ref="SlevomatCodingStandard.ControlStructures.RequireNullCoalesceOperator"/>
-    <rule ref="SlevomatCodingStandard.ControlStructures.EarlyExit"/>
+    <rule ref="SlevomatCodingStandard.ControlStructures.EarlyExit">
+        <properties>
+            <property name="ignoreStandaloneIfInScope" value="true">
+        </properties>
+    </rule>
     <rule ref="SlevomatCodingStandard.Functions.StaticClosure"/>
     <rule ref="SlevomatCodingStandard.Operators.DisallowEqualOperators"/>
     <rule ref="SlevomatCodingStandard.Operators.DisallowIncrementAndDecrementOperators"/>


### PR DESCRIPTION
`ignoreStandaloneIfInScope` ignores an `if` that is standalone within a scope (see [sniff description](https://github.com/slevomat/coding-standard/blob/master/doc/control-structures.md#slevomatcodingstandardcontrolstructuresearlyexit-)).

Without setting `ignoreStandaloneIfInScope` to true, Slevomat enforces changing this:

```php
public function __construct(string $currentWorkingDirectory)
{
    if (self::requireFileExistsExists()) {
        $this->requireFileExistsRule = new PHPStanRequireFileExistsRule($currentWorkingDirectory);
    }
}
```

to this:

```php
public function __construct(string $currentWorkingDirectory)
{
    if (! self::requireFileExistsExists()) {
        return;
    }
    $this->requireFileExistsRule = new PHPStanRequireFileExistsRule($currentWorkingDirectory);
}
```

with the following error message: `Use early exit to reduce code nesting.` Clearly, the nesting is not reduced, and I would argue that a layer of complexity is added.