### PR TITLE
Remove SlevomatCodingStandard.Functions.UnusedParameter

### DIFF
--- a/PSR12NeutronRuleset/ruleset.xml
+++ b/PSR12NeutronRuleset/ruleset.xml
@@ -221,7 +221,6 @@
     <rule ref="SlevomatCodingStandard.Numbers.DisallowNumericLiteralSeparator"/>
     <!-- Cleaning -->
     <rule ref="SlevomatCodingStandard.Functions.UnusedInheritedVariablePassedToClosure"/>
-    <rule ref="SlevomatCodingStandard.Functions.UnusedParameter"/>
     <rule ref="SlevomatCodingStandard.Functions.UselessParameterDefaultValue"/>
     <rule ref="SlevomatCodingStandard.Namespaces.UnusedUses"/>
     <rule ref="SlevomatCodingStandard.Namespaces.UseFromSameNamespace"/>

--- a/PSR12NeutronRuleset/ruleset.xml
+++ b/PSR12NeutronRuleset/ruleset.xml
@@ -181,6 +181,10 @@
         </properties>
     </rule>
 
+    <rule ref="Generic.CodeAnalysis.UnusedFunctionParameter"/>
+        <type>error</type>
+    </rule>
+
     <!-- TODO
     Look-and-See: https://github.com/squizlabs/PHP_CodeSniffer/tree/master/src/Standards/Squiz/Sniffs/PHP
     -->

--- a/PSR12NeutronRuleset/ruleset.xml
+++ b/PSR12NeutronRuleset/ruleset.xml
@@ -181,7 +181,7 @@
         </properties>
     </rule>
 
-    <rule ref="Generic.CodeAnalysis.UnusedFunctionParameter"/>
+    <rule ref="Generic.CodeAnalysis.UnusedFunctionParameter">
         <type>error</type>
     </rule>
 


### PR DESCRIPTION
Covered by Generic.CodeAnalysis.UnusedFunctionParameter included via WordPress standard