### PR TITLE
Fix Squiz.WhiteSpace.FunctionSpacin

### DIFF
--- a/PSR12NeutronRuleset/ruleset.xml
+++ b/PSR12NeutronRuleset/ruleset.xml
@@ -178,6 +178,8 @@
     <rule ref="Squiz.WhiteSpace.FunctionSpacing">
         <properties>
             <property name="spacing" value="1"/>
+            <property name="spacingBeforeFirst" value="0"/>
+            <property name="spacingAfterLast" value="0"/>
         </properties>
     </rule>
 


### PR DESCRIPTION
In #25 NeutronStandard.Whitespace.NewlineBetweenFunctions.MissingNewline was replaced by Squiz.WhiteSpace.FunctionSpacing. Squiz.WhiteSpace.FunctionSpacing needs a separate configuration for the first and last method.