### PR TITLE
Remove SlevomatCodingStandard.Arrays.TrailingArrayComma

### DIFF
--- a/PSR12NeutronRuleset/ruleset.xml
+++ b/PSR12NeutronRuleset/ruleset.xml
@@ -239,7 +239,6 @@
     <rule ref="SlevomatCodingStandard.Variables.UselessVariable"/>
     <rule ref="SlevomatCodingStandard.Exceptions.DeadCatch"/>
     <!-- Formatting -->
-    <rule ref="SlevomatCodingStandard.Arrays.TrailingArrayComma"/>
     <rule ref="SlevomatCodingStandard.Classes.ModernClassNameReference"/>
     <rule ref="SlevomatCodingStandard.Classes.SuperfluousAbstractClassNaming"/>
     <rule ref="SlevomatCodingStandard.Classes.SuperfluousInterfaceNaming"/>


### PR DESCRIPTION
Covered by NormalizedArrays.Arrays.CommaAfterLast included via WordPress Standard