### PR TITLE
Update workflows

### DIFF
--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -9,7 +9,7 @@ on:  # yamllint disable-line rule:truthy
 jobs:
     typos:
         name: "Typos"
-        runs-on: "ubuntu-latest"
+        runs-on: "ubuntu-22.04"
         steps:
         -
             name: "Check out repository"

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -9,11 +9,11 @@ on:  # yamllint disable-line rule:truthy
 jobs:
     typos:
         name: "Typos"
-        runs-on: "ubuntu-22.04"
+        runs-on: "ubuntu-latest"
         steps:
         -
             name: "Check out repository"
-            uses: "actions/checkout@v3"
+            uses: "actions/checkout@v4"
         -
             name: "Search for misspellings"
             uses: "crate-ci/typos@master"

--- a/.github/workflows/xml-validate.yml
+++ b/.github/workflows/xml-validate.yml
@@ -9,7 +9,7 @@ on:  # yamllint disable-line rule:truthy
 jobs:
     phpcs-validate:
         name: "Validate PHPCS ruleset"
-        runs-on: "ubuntu-latest"
+        runs-on: "ubuntu-22.04"
         steps:
         -
             name: "Check out repository"

--- a/.github/workflows/xml-validate.yml
+++ b/.github/workflows/xml-validate.yml
@@ -9,11 +9,11 @@ on:  # yamllint disable-line rule:truthy
 jobs:
     phpcs-validate:
         name: "Validate PHPCS ruleset"
-        runs-on: "ubuntu-22.04"
+        runs-on: "ubuntu-latest"
         steps:
         -
             name: "Check out repository"
-            uses: "actions/checkout@v3"
+            uses: "actions/checkout@v4"
         -
             name: "Set up PHP"
             uses: "shivammathur/setup-php@v2"
@@ -21,7 +21,7 @@ jobs:
                 php-version: "8.0"
         -
             name: "Install dependencies"
-            uses: "ramsey/composer-install@v2"
+            uses: "ramsey/composer-install@v3"
             with:
                 dependency-versions: "highest"
                 composer-options: "--no-plugins --no-scripts"


### PR DESCRIPTION
and get rid of the warning about the deprecated Node.js version.

![image](https://github.com/user-attachments/assets/47ccdddd-2fad-478e-8877-158b07bfd2b0)
