### PR TITLE
Remove Squiz.Strings.ConcatenationSpacing

### DIFF
--- a/PSR12NeutronRuleset/NeutronRuleset.xml
+++ b/PSR12NeutronRuleset/NeutronRuleset.xml
@@ -96,4 +96,7 @@
     <rule ref="Generic.Arrays.DisallowShortArraySyntax">
         <severity>0</severity>
     </rule>
+    <rule ref="Squiz.Strings.ConcatenationSpacing">
+        <severity>0</severity>
+    </rule>
 </ruleset>

--- a/PSR12NeutronRuleset/ruleset.xml
+++ b/PSR12NeutronRuleset/ruleset.xml
@@ -2,7 +2,9 @@
 <ruleset name="PSR12NeutronRuleset">
     <description>PSR-12 and Neutron hybrid Ruleset.</description>
 
-    <rule ref="PSR12"/>
+    <rule ref="PSR12">
+        <exclude name="PSR12.Operators.OperatorSpacing"/>
+    </rule>
 
     <!-- Bad parts of PHP -->
     <rule ref="Generic.PHP.NoSilencedErrors"/>

--- a/PSR12NeutronRuleset/ruleset.xml
+++ b/PSR12NeutronRuleset/ruleset.xml
@@ -2,9 +2,7 @@
 <ruleset name="PSR12NeutronRuleset">
     <description>PSR-12 and Neutron hybrid Ruleset.</description>
 
-    <rule ref="PSR12">
-        <exclude name="PSR12.Operators.OperatorSpacing"/>
-    </rule>
+    <rule ref="PSR12"/>
 
     <!-- Bad parts of PHP -->
     <rule ref="Generic.PHP.NoSilencedErrors"/>


### PR DESCRIPTION
We discourage concat usage in `PSR12NeutronRuleset.Strings.ConcatenationUsage`